### PR TITLE
Get rid of the hardcoded limit of 10 tweets.

### DIFF
--- a/src/twitter/twitter-posts/twitterhometimelinesyncadaptor.cpp
+++ b/src/twitter/twitter-posts/twitterhometimelinesyncadaptor.cpp
@@ -103,7 +103,6 @@ void TwitterHomeTimelineSyncAdaptor::requestPosts(int accountId, const QString &
                                                   const QString &sinceTweetId, const QString &fromUserId)
 {
     QList<QPair<QString, QString> > queryItems;
-    queryItems.append(QPair<QString, QString>(QString(QLatin1String("count")), QString(QLatin1String("10")))); // limit to 10 Tweets.
     if (!sinceTweetId.isEmpty()) {
         queryItems.append(QPair<QString, QString>(QString(QLatin1String("since_id")), sinceTweetId));
     }


### PR DESCRIPTION
Fixes https://together.jolla.com/question/2109/show-more-than-10-tweets-in-events/