### PR TITLE
[base-sociald] Don't overwrite URL query part for paged Facebook image r...

### DIFF
--- a/src/facebook/facebook-images/facebookimagesyncadaptor.cpp
+++ b/src/facebook/facebook-images/facebookimagesyncadaptor.cpp
@@ -123,14 +123,15 @@ void FacebookImageSyncAdaptor::requestData(int accountId,
         }
     }
 
-    QList<QPair<QString, QString> > queryItems;
-    QUrlQuery query(url);
-    if (!url.toString().contains("access_token")) {
+    // if the url already contains query part (in which case it is continuationUrl), don't overwrite it.
+    if (!url.hasQuery()) {
+        QList<QPair<QString, QString> > queryItems;
+        QUrlQuery query(url);
         queryItems.append(QPair<QString, QString>(QString(QLatin1String("access_token")), accessToken));
+        queryItems.append(QPair<QString, QString>(QString(QLatin1String("limit")), QString(QLatin1String("2000"))));
+        query.setQueryItems(queryItems);
+        url.setQuery(query);
     }
-    queryItems.append(QPair<QString, QString>(QString(QLatin1String("limit")), QString(QLatin1String("2000"))));
-    query.setQueryItems(queryItems);
-    url.setQuery(query);
 
     QNetworkReply *reply = networkAccessManager->get(QNetworkRequest(url));
     if (reply) {
@@ -265,7 +266,6 @@ void FacebookImageSyncAdaptor::albumsFinishedHandler()
 
 void FacebookImageSyncAdaptor::imagesFinishedHandler()
 {
-
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     bool isError = reply->property("isError").toBool();
     int accountId = reply->property("accountId").toInt();


### PR DESCRIPTION
...equests

The continuationUrl for paged Facebook image requests already contains access token. The current image sync code concludes that access token doesn't need to be added to queryItems because it is already part of the url but then overwites it by setting url query part without it. The result is that paged Facebook image queries fail and an album containing more than 100 images is not synced correctly.

Fixed by letting existing query part (which must come from continuationUrl) to pass through unmodified.
