### PR TITLE
[base-sociald] Fixed purging removed Facebook albums

### DIFF
--- a/src/facebook/facebook-images/facebookimagesyncadaptor.h
+++ b/src/facebook/facebook-images/facebookimagesyncadaptor.h
@@ -67,7 +67,7 @@ private Q_SLOTS:
 
 private:
     // for server-side removal detection.
-    void initRemovalDetectionLists();
+    bool initRemovalDetectionLists(int accountId);
     void clearRemovalDetectionLists();
     void checkRemovedImages(const QString &fbAlbumId);
     QMap<QString, FacebookAlbum::ConstPtr> m_cachedAlbums;


### PR DESCRIPTION
Currently initRemovalDetectionLists() relies on FacebookImagesDatabase::albums() method when it fills the list of cached Facebook albums. The method is used as if it was synchronous, but it is actually part of aynchronous queryAlbums() -> albums() sequence. Now queryAlbums() is never called so the resulting list is always empty. The removal detection mechanism uses that list and therefore didn't work. That list is also used when the image syncer checks if the remote album has been modified since the previous sync. Because that check now always fails, we eneded up syncing all the albums every time.

Fixed so that  initRemovalDetectionLists() uses synchronous allAlbumIds() instead (and cleaned away some old commented code).
