### PR TITLE
[sociald] Use server timestamps when delta-syncing google calendar event...

### DIFF
--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -819,6 +819,9 @@ void GoogleCalendarSyncAdaptor::updateLocalCalendarNotebookEvents(int accountId,
             // delete existing event.
             remoteRemoved++;
 
+            // if modified locally and deleted on server side, don't upsync modifications
+            updatedMap.remove(eventId);
+
             m_idDb.removeEvent(accountId, eventId);
             if (allMap.contains(eventId)) {
                 m_calendar->deleteEvent(allMap.value(eventId));

--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -44,6 +44,8 @@
 
 namespace {
 
+static int GOOGLE_CAL_SYNC_PLUGIN_VERSION = 2;
+
 QString gCalEventId(KCalCore::Incidence::Ptr event)
 {
     return event->customProperty("jolla-sociald", "gcal-id");
@@ -298,6 +300,12 @@ bool wasLastSyncSuccessful(int accountId)
     QSettings settingsFile(settingsFileName, QSettings::IniFormat);
     bool retn = settingsFile.value(QString::fromLatin1("%1-success").arg(accountId), QVariant::fromValue<bool>(false)).toBool();
     settingsFile.setValue(QString::fromLatin1("%1-success").arg(accountId), QVariant::fromValue<bool>(false));
+    int pluginVersion = settingsFile.value(QString::fromLatin1("%1-pluginVersion").arg(accountId), QVariant::fromValue<int>(1)).toInt();
+    if (pluginVersion != GOOGLE_CAL_SYNC_PLUGIN_VERSION) {
+        settingsFile.setValue(QString::fromLatin1("%1-pluginVersion").arg(accountId), GOOGLE_CAL_SYNC_PLUGIN_VERSION);
+        SOCIALD_LOG_DEBUG("Google cal sync plugin version mismatch, force clean sync");
+        retn = false;
+    }
     settingsFile.sync();
     return retn;
 }

--- a/src/google/google-calendars/googlecalendarsyncadaptor.h
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.h
@@ -60,7 +60,7 @@ private:
     void requestCalendars(int accountId, const QString &accessToken,
                           bool needCleanSync, const QString &pageToken = QString());
     void requestEvents(int accountId, const QString &accessToken,
-                       const QString &calendarId, const QDateTime &since,
+                       const QString &calendarId, bool needCleanSync,
                        const QString &pageToken = QString());
     void updateLocalCalendarNotebooks(int accountId, const QString &accessToken, bool needCleanSync);
     void updateLocalCalendarNotebookEvents(int accountId, const QString &accessToken,


### PR DESCRIPTION
...s

Google calendar sync plugin uses timestamp from previous completed buteo sync
round when requesting events for delta sync. This causes problems if the
device clock is behind the server clock. Say the following takes place:
user creates an event on device, upsyncs it at which point the sync plugin
saves a local timestamp. Then user edits the same event and saves it,
which triggers sync. Sync plugin requests changed events by using the timestamp
from previous round. As that timestamp is behind the server clock, the response
also includes the event user just edited. Sync plugin thinks that both
local and server side versions of the event have changed.
In that case, the server side version wins, effectively canceling the
changes user just did.

This commit takes timestamps from server responses, stores them
per-calendar basis to libsocialcache database and uses those values when
requesting events for delta sync.