### PR TITLE
[buteo-sync-plugins-social] Update to libaccounts-qt version 1.13

### DIFF
--- a/rpm/sociald.spec
+++ b/rpm/sociald.spec
@@ -14,7 +14,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(buteosyncfw5) >= 0.6.36
 BuildRequires:  pkgconfig(libsignon-qt5)
-BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(socialcache) >= 0.0.31
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  qt5-qttools-linguist

--- a/src/common/socialdbuteoplugin.cpp
+++ b/src/common/socialdbuteoplugin.cpp
@@ -269,7 +269,7 @@ QList<Buteo::SyncProfile*> SocialdButeoPlugin::ensurePerAccountSyncProfilesExist
     }
 
     for (int i = 0; i < accountIds.size(); ++i) {
-        Accounts::Account *currAccount = am.account(accountIds.at(i));
+        Accounts::Account *currAccount = Accounts::Account::fromId(&am, accountIds.at(i), this);
         if (!currAccount || currAccount->id() == 0
                 || m_socialNetworkSyncAdaptor->syncServiceName().split('-').first() != currAccount->providerName()) {
             // we only generate per-account sync profiles for accounts which

--- a/src/facebook/facebook-contacts/facebookcontactsyncadaptor.cpp
+++ b/src/facebook/facebook-contacts/facebookcontactsyncadaptor.cpp
@@ -984,7 +984,7 @@ void FacebookContactSyncAdaptor::finalCleanup()
         currentAccountIds.append(static_cast<int>(uaid));
     }
     foreach (int currId, currentAccountIds) {
-        Accounts::Account *act = m_accountManager->account(currId);
+        Accounts::Account *act = Accounts::Account::fromId(m_accountManager, currId, this);
         if (act) {
             if (act->providerName() == QString(QLatin1String("facebook")) && checkAccount(act)) {
                 facebookAccountIds.append(currId);

--- a/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
+++ b/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
@@ -167,7 +167,7 @@ Accounts::Account *FacebookSignonSyncAdaptor::loadAccount(int accountId)
     if (m_accounts.contains(accountId)) {
         acc = m_accounts[accountId];
     } else {
-        acc = m_accountManager.account(accountId);
+        acc = Accounts::Account::fromId(&m_accountManager, accountId, this);
         if (!acc) {
             SOCIALD_LOG_ERROR("Facebook account" << accountId << "was deleted during signon refresh sync");
             return 0;

--- a/src/facebook/facebookdatatypesyncadaptor.cpp
+++ b/src/facebook/facebookdatatypesyncadaptor.cpp
@@ -73,7 +73,7 @@ void FacebookDataTypeSyncAdaptor::sync(const QString &dataTypeString, int accoun
 
 void FacebookDataTypeSyncAdaptor::updateDataForAccount(int accountId)
 {
-    Accounts::Account *account = m_accountManager->account(accountId);
+    Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
     if (!account) {
         SOCIALD_LOG_ERROR("existing account with id" << accountId << "couldn't be retrieved");
         setStatus(SocialNetworkSyncAdaptor::Error);
@@ -105,7 +105,7 @@ void FacebookDataTypeSyncAdaptor::errorHandler(QNetworkReply::NetworkError err)
         if (errorReply.value("code").toDouble() == 190 &&
                 errorReply.value("error_subcode").toDouble() == 460) {
             int accountId = reply->property("accountId").toInt();
-            Accounts::Account *account = m_accountManager->account(accountId);
+            Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
             if (account) {
                 setCredentialsNeedUpdate(account);
             }

--- a/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
+++ b/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
@@ -101,7 +101,7 @@ void GoogleTwoWayContactSyncAdaptor::purgeDataForOldAccount(int oldId, SocialNet
 
 void GoogleTwoWayContactSyncAdaptor::beginSync(int accountId, const QString &accessToken)
 {
-    Accounts::Account *account = m_accountManager->account(accountId);
+    Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
     if (!account) {
         SOCIALD_LOG_ERROR("unable to load Google account" << accountId);
         setStatus(SocialNetworkSyncAdaptor::Error);
@@ -870,7 +870,7 @@ void GoogleTwoWayContactSyncAdaptor::finalCleanup()
         currentAccountIds.append(static_cast<int>(uaid));
     }
     foreach (int currId, currentAccountIds) {
-        Accounts::Account *act = m_accountManager->account(currId);
+        Accounts::Account *act = Accounts::Account::fromId(m_accountManager, currId, this);
         if (act) {
             if (act->providerName() == QString(QLatin1String("google"))) {
                 // this account still exists, no need to purge its content.

--- a/src/google/google-signon/googlesignonsyncadaptor.cpp
+++ b/src/google/google-signon/googlesignonsyncadaptor.cpp
@@ -73,7 +73,7 @@ Accounts::Account *GoogleSignonSyncAdaptor::loadAccount(int accountId)
     if (m_accounts.contains(accountId)) {
         acc = m_accounts[accountId];
     } else {
-        acc = m_accountManager.account(accountId);
+        acc = Accounts::Account::fromId(&m_accountManager, accountId, this);
         if (!acc) {
             SOCIALD_LOG_ERROR(
                     QString(QLatin1String("error: Google account %1 was deleted during signon refresh sync"))

--- a/src/google/googledatatypesyncadaptor.cpp
+++ b/src/google/googledatatypesyncadaptor.cpp
@@ -79,7 +79,7 @@ void GoogleDataTypeSyncAdaptor::sync(const QString &dataTypeString, int accountI
 
 void GoogleDataTypeSyncAdaptor::updateDataForAccount(int accountId)
 {
-    Accounts::Account *account = m_accountManager->account(accountId);
+    Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
     if (!account) {
         SOCIALD_LOG_ERROR("existing account with id" << accountId << "couldn't be retrieved");
         setStatus(SocialNetworkSyncAdaptor::Error);

--- a/src/twitter/twitterdatatypesyncadaptor.cpp
+++ b/src/twitter/twitterdatatypesyncadaptor.cpp
@@ -80,7 +80,7 @@ void TwitterDataTypeSyncAdaptor::sync(const QString &dataTypeString, int account
 
 void TwitterDataTypeSyncAdaptor::updateDataForAccount(int accountId)
 {
-    Accounts::Account *account = m_accountManager->account(accountId);
+    Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
     if (!account) {
         SOCIALD_LOG_ERROR("existing account with id" << accountId << "couldn't be retrieved");
         setStatus(SocialNetworkSyncAdaptor::Error);
@@ -133,7 +133,7 @@ void TwitterDataTypeSyncAdaptor::errorHandler(QNetworkReply::NetworkError err)
         foreach (QJsonValue data, dataList) {
             QJsonObject dataMap = data.toObject();
             if (dataMap.value("code").toDouble() == 32 || dataMap.value("code").toDouble() == 89) {
-                Accounts::Account *account = m_accountManager->account(accountId);
+                Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
                 if (account) {
                     setCredentialsNeedUpdate(account);
                 }


### PR DESCRIPTION
This commit ensures that we use the Accounts::Account::fromId()
function rather than Accounts::Manager::account() function to
retrieve an account instance whose lifetime we wish to control,
as using the latter function can now cause crashes due to a change
made between version 1.6 and 1.7 in libaccounts-qt.