### PR TITLE
[buteo-sync-plugins-social] Improve logging from signon adapters

### DIFF
--- a/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
+++ b/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
@@ -133,9 +133,9 @@ void FacebookSignonSyncAdaptor::requestFinishedHandler()
                     || errorCode == 10
                     || (errorCode >= 200 && errorCode <= 299)) {
                 // the account is in a state which requires user intervention
-                forceTokenExpiry(0, accountId, accessToken);
-                SOCIALD_LOG_DEBUG("access token has expired for Facebook account" << accountId <<
+                SOCIALD_LOG_ERROR("access token has expired for Facebook account" << accountId <<
                                   ":" <<  errorCode << "," << errorType << "," << errorMessage);
+                forceTokenExpiry(0, accountId, accessToken);
             } else {
                 // other error (downtime / service disruption / etc)
                 // ignore this one.
@@ -150,8 +150,8 @@ void FacebookSignonSyncAdaptor::requestFinishedHandler()
         // if the token has been manually revoked.  There is no
         // response data in this case.
         // the account is in a state which requires user intervention
+        SOCIALD_LOG_ERROR("access token has presumably been revoked for Facebook account" << accountId);
         forceTokenExpiry(0, accountId, accessToken);
-        SOCIALD_LOG_DEBUG("access token has presumably expired for Facebook account" << accountId);
     } else {
         // could have been a network error, or something.
         // we treat it as a sync error, but not a signon error.
@@ -190,6 +190,7 @@ void FacebookSignonSyncAdaptor::raiseCredentialsNeedUpdateFlag(int accountId)
 {
     Accounts::Account *acc = loadAccount(accountId);
     if (acc) {
+        SOCIALD_LOG_ERROR("FBSSA: raising CredentialsNeedUpdate flag");
         Accounts::Service srv = m_accountManager.service(syncServiceName());
         acc->selectService(srv);
         acc->setValue(QStringLiteral("CredentialsNeedUpdate"), QVariant::fromValue<bool>(true));
@@ -203,6 +204,7 @@ void FacebookSignonSyncAdaptor::lowerCredentialsNeedUpdateFlag(int accountId)
 {
     Accounts::Account *acc = loadAccount(accountId);
     if (acc) {
+        SOCIALD_LOG_ERROR("FBSSA: lowering CredentialsNeedUpdate flag");
         Accounts::Service srv = m_accountManager.service(syncServiceName());
         acc->selectService(srv);
         acc->setValue(QStringLiteral("CredentialsNeedUpdate"), QVariant::fromValue<bool>(false));
@@ -282,6 +284,7 @@ void FacebookSignonSyncAdaptor::forceTokenExpiryResponse(const SignOn::SessionDa
 
     if (seconds == 0) {
         // successfully forced expiry
+        SOCIALD_LOG_ERROR("forced expiry for reportedly invalid token");
         raiseCredentialsNeedUpdateFlag(accountId);
     } else {
         // successfully forced new ExpiresIn value
@@ -301,6 +304,7 @@ void FacebookSignonSyncAdaptor::forceTokenExpiryError(const SignOn::Error &error
 
     if (seconds == 0) {
         // we treat the error as if it was a success, since we need to update the credentials anyway.
+        SOCIALD_LOG_ERROR("forced expiry for reportedly invalid token failed");
         raiseCredentialsNeedUpdateFlag(accountId);
     } else {
         // don't raise or lower the flag.  If was previously not raised,

--- a/src/facebook/facebookdatatypesyncadaptor.cpp
+++ b/src/facebook/facebookdatatypesyncadaptor.cpp
@@ -220,7 +220,7 @@ void FacebookDataTypeSyncAdaptor::signOnError(const SignOn::Error &error)
 
     // if the error is because credentials have expired, we
     // set the CredentialsNeedUpdate key.
-    if (error.type() == SignOn::AuthSession::UserInteractionError) {
+    if (error.type() == SignOn::Error::UserInteraction) {
         setCredentialsNeedUpdate(account);
     }
 

--- a/src/google/google-signon/googlesignonsyncadaptor.cpp
+++ b/src/google/google-signon/googlesignonsyncadaptor.cpp
@@ -99,6 +99,7 @@ void GoogleSignonSyncAdaptor::raiseCredentialsNeedUpdateFlag(int accountId)
 {
     Accounts::Account *acc = loadAccount(accountId);
     if (acc) {
+        SOCIALD_LOG_ERROR("GSSA: raising CredentialsNeedUpdate flag");
         Accounts::Service srv = m_accountManager.service(syncServiceName());
         acc->selectService(srv);
         acc->setValue(QStringLiteral("CredentialsNeedUpdate"), QVariant::fromValue<bool>(true));
@@ -112,6 +113,7 @@ void GoogleSignonSyncAdaptor::lowerCredentialsNeedUpdateFlag(int accountId)
 {
     Accounts::Account *acc = loadAccount(accountId);
     if (acc) {
+        SOCIALD_LOG_ERROR("GSSA: lowering CredentialsNeedUpdate flag");
         Accounts::Service srv = m_accountManager.service(syncServiceName());
         acc->selectService(srv);
         acc->setValue(QStringLiteral("CredentialsNeedUpdate"), QVariant::fromValue<bool>(false));
@@ -277,13 +279,13 @@ void GoogleSignonSyncAdaptor::signonError(const SignOn::Error &error)
         session->deleteLater();
     }
 
-    bool raiseFlag = error.type() == SignOn::AuthSession::UserInteractionError;
+    bool raiseFlag = error.type() == SignOn::Error::UserInteraction;
     SOCIALD_LOG_INFO(
             QString(QLatin1String("got signon error when performing signon refresh for Google account %1: %2: %3.  Raising flag? %4"))
             .arg(accountId).arg(error.type()).arg(error.message()).arg(raiseFlag));
 
     if (raiseFlag) {
-        // UserInteractionError is returned if user interaction is required.
+        // UserInteraction error is returned if user interaction is required.
         raiseCredentialsNeedUpdateFlag(accountId);
     }
 

--- a/src/google/googledatatypesyncadaptor.cpp
+++ b/src/google/googledatatypesyncadaptor.cpp
@@ -264,7 +264,7 @@ void GoogleDataTypeSyncAdaptor::signOnError(const SignOn::Error &error)
 
     // if the error is because credentials have expired, we
     // set the CredentialsNeedUpdate key.
-    if (error.type() == SignOn::AuthSession::UserInteractionError) {
+    if (error.type() == SignOn::Error::UserInteraction) {
         setCredentialsNeedUpdate(account);
     }
 

--- a/src/twitter/twitterdatatypesyncadaptor.cpp
+++ b/src/twitter/twitterdatatypesyncadaptor.cpp
@@ -368,7 +368,7 @@ void TwitterDataTypeSyncAdaptor::signOnError(const SignOn::Error &error)
 
     // if the error is because credentials have expired, we
     // set the CredentialsNeedUpdate key.
-    if (error.type() == SignOn::AuthSession::UserInteractionError) {
+    if (error.type() == SignOn::Error::UserInteraction) {
         setCredentialsNeedUpdate(account);
     }
 


### PR DESCRIPTION
This commit improves the logging from the signon adapters, so that
we can more easily see which process is responsible for raising
the CredentialsNeedUpdate flag in user logs without requiring
msyncd to be run with MSYNCD_LOGGING_LEVEL=8 set.