### PR TITLE
[buteo-sync-plugins-social] Implement rudimentary connection-loss handling. Contributes to MER#885

### DIFF
--- a/src/common/socialdbuteoplugin.cpp
+++ b/src/common/socialdbuteoplugin.cpp
@@ -187,9 +187,11 @@ bool SocialdButeoPlugin::startSync()
     return false;
 }
 
-void SocialdButeoPlugin::abortSync(Sync::SyncStatus)
+void SocialdButeoPlugin::abortSync(Sync::SyncStatus status)
 {
-    // TODO
+    // note: it seems buteo automatically calls abortSync on network connectivity loss...
+    SOCIALD_LOG_INFO("aborting sync with status:" << status);
+    m_socialNetworkSyncAdaptor->abortSync(status);
 }
 
 bool SocialdButeoPlugin::cleanUp()
@@ -213,12 +215,15 @@ Buteo::SyncResults SocialdButeoPlugin::getSyncResults() const
     return m_syncResults;
 }
 
-void SocialdButeoPlugin::connectivityStateChanged(Sync::ConnectivityType, bool)
+void SocialdButeoPlugin::connectivityStateChanged(Sync::ConnectivityType type, bool state)
 {
-    // TODO, see TransportTracker.cpp:149
+    // See TransportTracker.cpp:149 for example
     // Sync::CONNECTIVITY_INTERNET, true|false
-    // Kill all ongoing on false
-    // "Free" single shot sync on wlan?
+    SOCIALD_LOG_INFO("notified of connectivity change:" << type << state);
+    if (type == Sync::CONNECTIVITY_INTERNET && state == false) {
+        // we lost connectivity during sync.
+        abortSync(Sync::SYNC_CONNECTION_ERROR);
+    }
 }
 
 void SocialdButeoPlugin::syncStatusChanged()

--- a/src/common/socialnetworksyncadaptor.h
+++ b/src/common/socialnetworksyncadaptor.h
@@ -87,8 +87,10 @@ public:
     Status status() const;
     bool enabled() const;
     QString serviceName() const;
+
     virtual void sync(const QString &dataType, int accountId = 0);
     virtual void purgeDataForOldAccount(int accountId, PurgeMode mode = SyncPurge) = 0;
+    virtual void abortSync(Sync::SyncStatus status);
 
 Q_SIGNALS:
     void statusChanged();
@@ -107,6 +109,9 @@ protected:
     void setInitialActive(bool enabled);
     void setFinishedInactive();
 
+    // whether the sync has been aborted (perhaps due to network connection loss)
+    bool syncAborted() const;
+
     // Semaphore system
     void incrementSemaphore(int accountId);
     void decrementSemaphore(int accountId);
@@ -114,6 +119,7 @@ protected:
     // network reply timeouts
     void setupReplyTimeout(int accountId, QNetworkReply *reply);
     void removeReplyTimeout(int accountId, QNetworkReply *reply);
+    void triggerReplyTimeouts();
 
     // Parsing methods
     static QJsonObject parseJsonObjectReplyData(const QByteArray &replyData, bool *ok);
@@ -131,6 +137,7 @@ private:
     SocialNetworkSyncDatabase *m_syncDb;
     SocialNetworkSyncAdaptor::Status m_status;
     bool m_enabled;
+    bool m_syncAborted;
     QString m_serviceName;
     QMap<int, int> m_accountSyncSemaphores;
     QMap<int, QMap<QNetworkReply*, QTimer *> > m_networkReplyTimeouts;

--- a/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
+++ b/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.cpp
@@ -105,6 +105,12 @@ void FacebookCalendarSyncAdaptor::sync(const QString &dataTypeString, int accoun
 
 void FacebookCalendarSyncAdaptor::finalCleanup()
 {
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, won't commit database changes");
+        m_storage->close();
+        return;
+    }
+
     // commit changes to db
     if (m_storageNeedsSave) {
         m_storage->save();
@@ -140,7 +146,6 @@ void FacebookCalendarSyncAdaptor::finalCleanup()
         if (!m_storageNeedsSave || m_storage->save()) {
             setGhostEventCleanupPerformed();
         }
-
     }
 
     // done.

--- a/src/facebook/facebook-contacts/facebookcontactsyncadaptor.cpp
+++ b/src/facebook/facebook-contacts/facebookcontactsyncadaptor.cpp
@@ -765,6 +765,11 @@ bool FacebookContactSyncAdaptor::storeToLocal(const QString &accessToken, int ac
 {
     Q_UNUSED(accessToken)
 
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, won't commit database changes");
+        return false;
+    }
+
     // steps:
     // 1) load current data from backend
     // 2) determine delta (add/mod/rem)

--- a/src/facebook/facebook-contacts/facebookcontactsyncadaptor.h
+++ b/src/facebook/facebook-contacts/facebookcontactsyncadaptor.h
@@ -72,6 +72,7 @@ private Q_SLOTS:
 private:
     QContactManager *m_contactManager;
     FacebookContactImageDownloader *m_workerObject;
+
     QMap<int, QList<QContact> > m_remoteContacts; // accountId to contacts to save.
     QMap<int, QList<QPair<QString, QVariantMap> > > m_queuedAvatarDownloads;
 

--- a/src/facebook/facebook-notifications/facebooknotificationsyncadaptor.cpp
+++ b/src/facebook/facebook-notifications/facebooknotificationsyncadaptor.cpp
@@ -58,9 +58,13 @@ void FacebookNotificationSyncAdaptor::beginSync(int accountId, const QString &ac
 void FacebookNotificationSyncAdaptor::finalize(int accountId)
 {
     Q_UNUSED(accountId)
-    m_db.purgeOldNotifications(OLD_NOTIFICATION_LIMIT_IN_DAYS);
-    m_db.sync();
-    m_db.wait();
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, won't commit database changes");
+    } else {
+        m_db.purgeOldNotifications(OLD_NOTIFICATION_LIMIT_IN_DAYS);
+        m_db.sync();
+        m_db.wait();
+    }
 }
 
 void FacebookNotificationSyncAdaptor::requestNotifications(int accountId, const QString &accessToken, const QString &until, const QString &pagingToken)

--- a/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
+++ b/src/facebook/facebook-signon/facebooksignonsyncadaptor.cpp
@@ -112,6 +112,12 @@ void FacebookSignonSyncAdaptor::requestFinishedHandler()
     reply->deleteLater();
     removeReplyTimeout(accountId, reply);
 
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, skipping signon sync reply handling");
+        decrementSemaphore(accountId);
+        return;
+    }
+
     bool ok = false;
     QJsonObject parsed = parseJsonObjectReplyData(replyData, &ok);
     if (!isError && ok && parsed.contains(QStringLiteral("id"))) {

--- a/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
+++ b/src/google/google-contacts/googletwowaycontactsyncadaptor.cpp
@@ -384,6 +384,15 @@ void GoogleTwoWayContactSyncAdaptor::contactsFinishedHandler()
 
 void GoogleTwoWayContactSyncAdaptor::continueSync(int accountId, const QString &accessToken)
 {
+    // early out in case we lost connectivity
+    if (syncAborted()) {
+        SOCIALD_LOG_ERROR("aborting sync of account" << accountId);
+        purgeSyncStateData(QString::number(accountId));
+        setStatus(SocialNetworkSyncAdaptor::Error);
+        // note: don't decrement here - it's done by contactsFinishedHandler().
+        return;
+    }
+
     // for each of the addmods, we need to fixup the contact avatars.
     transformContactAvatars(m_remoteAddMods[accountId], accountId, accessToken);
 

--- a/src/twitter/twitter-notifications/twittermentiontimelinesyncadaptor.cpp
+++ b/src/twitter/twitter-notifications/twittermentiontimelinesyncadaptor.cpp
@@ -114,6 +114,12 @@ void TwitterMentionTimelineSyncAdaptor::finishedHandler()
     reply->deleteLater();
     removeReplyTimeout(accountId, reply);
 
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, ignoring request response");
+        decrementSemaphore(accountId);
+        return;
+    }
+
     bool ok = false;
     QJsonArray tweets = parseJsonArrayReplyData(replyData, &ok);
     if (ok) {

--- a/src/twitter/twitter-posts/twitterhometimelinesyncadaptor.cpp
+++ b/src/twitter/twitter-posts/twitterhometimelinesyncadaptor.cpp
@@ -56,8 +56,12 @@ void TwitterHomeTimelineSyncAdaptor::beginSync(int accountId, const QString &oau
 void TwitterHomeTimelineSyncAdaptor::finalize(int accountId)
 {
     Q_UNUSED(accountId)
-    m_db.commit();
-    m_db.wait();
+    if (syncAborted()) {
+        SOCIALD_LOG_INFO("sync aborted, won't commit database changes");
+    } else {
+        m_db.commit();
+        m_db.wait();
+    }
 }
 
 void TwitterHomeTimelineSyncAdaptor::requestMe(int accountId, const QString &oauthToken, const QString &oauthTokenSecret)


### PR DESCRIPTION
This commit adds basic handling for connection loss during sync.
In most cases, it detects the connection loss and then skips any
database commit during finalisation.
In some cases where this is not possible, it merely aborts proceeding
operations and marks the account for clean sync on next cycle.