### PR TITLE
[buteo-sync-plugins-social] Remove libsocialcache usage from Google Calendar sync. Contributes to MER#916

### DIFF
--- a/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.h
+++ b/src/facebook/facebook-calendars/facebookcalendarsyncadaptor.h
@@ -27,8 +27,6 @@
 #include <extendedcalendar.h>
 #include <extendedstorage.h>
 
-#include <socialcache/facebookcalendardatabase.h>
-
 class FacebookParsedEvent
 {
 public:
@@ -74,7 +72,6 @@ private Q_SLOTS:
 private:
     mKCal::ExtendedCalendar::Ptr m_calendar;
     mKCal::ExtendedStorage::Ptr m_storage;
-    FacebookCalendarDatabase m_db;
     bool m_storageNeedsSave;
     QMap<QString, FacebookParsedEvent> m_parsedEvents;
 };

--- a/src/google/google-calendars/googlecalendarsyncadaptor.h
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.h
@@ -34,8 +34,6 @@
 #include <icalformat.h>
 #include <kdatetime.h>
 
-#include <socialcache/googlecalendardatabase.h>
-
 class GoogleCalendarSyncAdaptor : public GoogleDataTypeSyncAdaptor
 {
     Q_OBJECT
@@ -114,8 +112,6 @@ private:
     mKCal::ExtendedStorage::Ptr m_storage;
     mutable KCalCore::ICalFormat m_icalFormat;
     bool m_storageNeedsSave;
-
-    GoogleCalendarDatabase m_idDb; // solely for local-deletion-upsync support
 };
 
 #endif // GOOGLECALENDARSYNCADAPTOR_H


### PR DESCRIPTION
This commit removes any usage of libsocialcache from the Google
Calendar sync adapter.  This means that sync is more robust and
less prone to problems due to improved atomicity.

Contributes to MER#916