### PR TITLE
[buteo-sync-plugins-social] Support downsyncing Google Calendar reminders. Contributes to MER#1071

### DIFF
--- a/src/google/google-calendars/googlecalendarsyncadaptor.h
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.h
@@ -88,6 +88,7 @@ private:
         ChangeType change;
     };
     QMap<int, QMap<QString, CalendarInfo> > m_serverCalendarIdToCalendarInfo;
+    QMap<int, QMap<QString, int> > m_serverCalendarIdToDefaultReminderTimes;
     QMap<int, QMultiMap<QString, QJsonObject> > m_calendarIdToEventObjects;
     QMap<int, QMap<QString, QString> > m_recurringEventIdToKCalUid;
     QMap<int, bool> m_syncSucceeded;


### PR DESCRIPTION
This commit adds support for downsyncing Google Calendar reminders.
It does not add support for upsyncing reminder data to Google.

Contributes to MER#1071