### PR TITLE
[buteo-sync-plugins-social] Don't raise notifications on first Twitter Notifications sync. Contributes to MER#1103

### DIFF
--- a/src/twitter/twitter-notifications/twitternotificationsyncadaptor.h
+++ b/src/twitter/twitter-notifications/twitternotificationsyncadaptor.h
@@ -73,6 +73,7 @@ private:
     TwitterNotificationsDatabase m_db;
     QDateTime m_lastSyncTimestamp;
     QSet<QString> m_followerIds;
+    bool m_firstTimeSync;
 };
 
 #endif // TWITTERNOTIFICATIONSYNCADAPTOR_H


### PR DESCRIPTION
This commit ensures we don't raise spurious notifications when the
user first adds their Twitter account.

Contributes to MER#1103