### PR TITLE
[buteo-sync-plugins-social] Don't perform clean sync of Google Calendars after upgrade. Contributes to MER#1162

### DIFF
--- a/rpm/sociald.spec
+++ b/rpm/sociald.spec
@@ -194,7 +194,6 @@ Provides calendar synchronisation with Google
 %pre google-calendars
 rm -f /home/nemo/.cache/msyncd/sync/client/google-calendars.xml
 rm -f /home/nemo/.cache/msyncd/sync/google.Calendars.xml
-rm -f /home/nemo/.local/share/system/privileged/Sync/gcal.ini
 
 %post google-calendars
 systemctl-user try-restart msyncd.service || :

--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -1310,10 +1310,12 @@ void GoogleCalendarSyncAdaptor::finishedRequestingRemoteEvents(int accountId, co
             case GoogleCalendarSyncAdaptor::CleanSync: {
                 SOCIALD_LOG_DEBUG("Deleting and recreating local notebook for clean-sync server calendar:" << serverCalendarId);
                 // delete
+                QString notebookUid; // we wish to re-use the old notebook's UID after clean sync.
                 mKCal::Notebook::Ptr notebook = notebookForCalendarId(accountId, serverCalendarId);
                 if (!notebook.isNull()) {
                     SOCIALD_LOG_DEBUG("deleting notebook:" << notebook->uid() << "due to clean sync");
                     notebook->setIsReadOnly(false);
+                    notebookUid = notebook->uid();
                     m_storage->deleteNotebook(notebook);
                 } else {
                     SOCIALD_LOG_DEBUG("could not find local notebook corresponding to server calendar:" << serverCalendarId);
@@ -1322,6 +1324,9 @@ void GoogleCalendarSyncAdaptor::finishedRequestingRemoteEvents(int accountId, co
                 SOCIALD_LOG_DEBUG("recreating notebook:" << notebook->uid() << "due to clean sync");
                 notebook = mKCal::Notebook::Ptr(new mKCal::Notebook);
                 notebook->setIsReadOnly(false);
+                if (!notebookUid.isEmpty()) {
+                    notebook->setUid(notebookUid);
+                }
                 notebook->setName(m_serverCalendarIdToCalendarInfo[accountId].value(serverCalendarId).summary);
                 notebook->setColor(m_serverCalendarIdToCalendarInfo[accountId].value(serverCalendarId).color);
                 notebook->setDescription(m_serverCalendarIdToCalendarInfo[accountId].value(serverCalendarId).description);


### PR DESCRIPTION
This commit ensures that we don't delete the gcal.ini file on package
upgrade, which we previously did (which would then trigger a clean
sync cycle on next synchronization).

Contributes to MER#1162