### PR TITLE
[buteo-sync-plugins-social] Guard notebook pointer access. Contributes to MER#1173

### DIFF
--- a/src/google/google-calendars/googlecalendarsyncadaptor.cpp
+++ b/src/google/google-calendars/googlecalendarsyncadaptor.cpp
@@ -1342,6 +1342,11 @@ void GoogleCalendarSyncAdaptor::finishedRequestingRemoteEvents(int accountId, co
     foreach (const QString &updatedCalendarId, m_calendarsFinishedRequested.keys()) {
         QString updateTimestamp = m_calendarsFinishedRequested.value(updatedCalendarId);
         mKCal::Notebook::Ptr notebook = notebookForCalendarId(accountId, updatedCalendarId);
+        if (!notebook) {
+            SOCIALD_LOG_ERROR("local notebook associated with calendar:" << updatedCalendarId << "from account:" << accountId << "was deleted during sync!");
+            m_syncSucceeded[accountId] = false;
+            continue; // but still continue, to ensure local database is in usable state.
+        }
         KDateTime syncDate = datetimeFromUpdateStr(updateTimestamp);
         notebook->setSyncDate(syncDate);
         m_storage->updateNotebook(notebook);


### PR DESCRIPTION
This commit ensures that we check the value of the notebook pointer
returned from the lookup function after asynchronous network requests
have finished, otherwise (if the local notebook is deleted during sync)
dereferencing this pointer can cause a crash.

Contributes to MER#1173