### PR TITLE
Use correct log macro when removing cached images. Fixes MER#1279

### DIFF
--- a/src/common/socialnetworksyncadaptor.cpp
+++ b/src/common/socialnetworksyncadaptor.cpp
@@ -437,7 +437,7 @@ void SocialNetworkSyncAdaptor::purgeCachedImages(SocialImagesDatabase *database,
 
     QList<SocialImage::ConstPtr> images = database->images();
     foreach (SocialImage::ConstPtr image, images) {
-        SOCIALD_LOG_ERROR("Purge cached image " << image->imageFile() << " for account " << image->accountId());
+        SOCIALD_LOG_DEBUG("Purge cached image " << image->imageFile() << " for account " << image->accountId());
         QFile::remove(image->imageFile());
     }
 
@@ -454,7 +454,7 @@ void SocialNetworkSyncAdaptor::purgeExpiredImages(SocialImagesDatabase *database
 
     QList<SocialImage::ConstPtr> images = database->images();
     foreach (SocialImage::ConstPtr image, images) {
-        SOCIALD_LOG_ERROR("Purge expired image " << image->imageFile() << " for account " << image->accountId());
+        SOCIALD_LOG_DEBUG("Purge expired image " << image->imageFile() << " for account " << image->accountId());
         QFile::remove(image->imageFile());
     }
 


### PR DESCRIPTION
SocialNetworkSyncAdaptor::purgeCachedImages and
SocialNetworkSyncAdaptor::purgeExpiredImages use SOCIALD_LOG_ERROR macro to
log cached image about to be removed. It should be SOCIALD_LOG_DEBUG instead.
Now journal is flooded with error messages when an account is (successfully)
removed.