### PR TITLE
socialimagesdatabase.h does not exist in libsocialcache 0.0.36

### DIFF
--- a/rpm/sociald.spec
+++ b/rpm/sociald.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(buteosyncfw5) >= 0.6.36
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
-BuildRequires:  pkgconfig(socialcache) >= 0.0.36
+BuildRequires:  pkgconfig(socialcache) >= 0.0.37
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  qt5-qttools-linguist
 Requires: buteo-syncfw-qt5-msyncd


### PR DESCRIPTION
socialnetworksyncadaptor.cpp includes socialcache/socialimagesdatabase.h.
This file was added with version 0.0.37.